### PR TITLE
Improve geocoding sample

### DIFF
--- a/Linux/Geocoding/batch_geocoding.sh
+++ b/Linux/Geocoding/batch_geocoding.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-url=http://www.route4me.com/api/geocoder.php
-apikey=11111111111111111111111111111111
-format=xml
-addrs="Los20%Angeles20%International20%Airport,20%CA"
-
 # The example refers to the process of the forward geocoding.
 
-curl -o file1.txt -g -X POST "$url?api_key=$apikey&format=$format&addresses=$addrs" 
+curl -o file1.txt -G -X GET http://www.route4me.com/api/geocoder.php \
+	-d api_key=11111111111111111111111111111111 \
+	-d format=json \
+	--data-urlencode addresses="Los Angeles International Airport, CA"
 
 echo "Finished..."
 


### PR DESCRIPTION
I tried to simplify the source-code for samples.

I used `-d` curl option to pass parameters in query string, when parameters requires url-encoding (for example, there are spaces) I use `--data-urlencode`

Moreover, in this case, original example contains an error in encoded parameter:

`Los20%Angeles20%International20%Airport,20%CA` - wrong `Los%20Angeles%20International%20Airport,%20CA` - correct